### PR TITLE
Added opaque user data enabled callbacks.

### DIFF
--- a/include/replxx.h
+++ b/include/replxx.h
@@ -73,16 +73,25 @@ struct replxx_color {
 typedef void (replxx_highlighter_callback_t)(char const* input, replxx_color::color* colors, int size);
 void replxx_set_highlighter_callback(replxx_highlighter_callback_t* fn);
 
+typedef void (replxx_ud_highlighter_callback_t)(char const* input, replxx_color::color* colors, int size, void* user_data);
+void replxx_set_ud_highlighter_callback(replxx_ud_highlighter_callback_t* fn, void* user_data);
+
 typedef struct replxx_completions replxx_completions;
 typedef void(replxx_completion_callback_t)(const char*, replxx_completions*);
+typedef void(replxx_ud_completion_callback_t)(const char*, replxx_completions*, void*);
 typedef void(replxx_ctx_completion_callback_t)(const char*, int, replxx_completions*);
+typedef void(replxx_ud_ctx_completion_callback_t)(const char*, int, replxx_completions*, void*);
 void replxx_set_completion_callback(replxx_completion_callback_t* fn);
+void replxx_set_ud_completion_callback(replxx_ud_completion_callback_t* fn, void* user_data);
 void replxx_set_ctx_completion_callback(replxx_ctx_completion_callback_t* fn);
+void replxx_set_ud_ctx_completion_callback(replxx_ud_ctx_completion_callback_t* fn, void* user_data);
 void replxx_add_completion(replxx_completions* lc, const char* str);
 
 typedef struct replxx_hints replxx_hints;
 typedef void(replxx_hint_callback_t)(const char*, int, replxx_hints*, replxx_color::color*);
+typedef void(replxx_ud_hint_callback_t)(const char*, int, replxx_hints*, replxx_color::color*, void*);
 void replxx_set_hint_callback(replxx_hint_callback_t* fn);
+void replxx_set_ud_hint_callback(replxx_ud_hint_callback_t* fn, void* user_data);
 void replxx_add_hint(replxx_hints* lh, const char* str);
 
 char* replxx_input(const char* prompt);

--- a/src/replxx.cpp
+++ b/src/replxx.cpp
@@ -430,17 +430,39 @@ void replxx_set_completion_callback(replxx_completion_callback_t* fn) {
 	setup.completionCallback = fn;
 }
 
+/* Register a callback function to be called for tab-completion. */
+void replxx_set_ud_completion_callback(replxx_ud_completion_callback_t* fn, void* user_data) {
+	setup.udCompletionCallback = fn;
+	setup.completionUserdata = user_data;
+}
+
 /* Register a callback function to be called for tab-ctx-completion. */
 void replxx_set_ctx_completion_callback(replxx_ctx_completion_callback_t* fn) {
 	setup.ctxCompletionCallback = fn;
+}
+
+/* Register a callback function to be called for tab-ctx-completion. */
+void replxx_set_ud_ctx_completion_callback(replxx_ud_ctx_completion_callback_t* fn, void* user_data) {
+	setup.udCtxCompletionCallback = fn;
+	setup.ctxCompletionUserdata = user_data;
 }
 
 void replxx_set_highlighter_callback(replxx_highlighter_callback_t* fn) {
 	setup.highlighterCallback = fn;
 }
 
+void replxx_set_ud_highlighter_callback(replxx_ud_highlighter_callback_t* fn, void* user_data) {
+	setup.udHighlighterCallback = fn;
+	setup.highlighterUserdata = user_data;
+}
+
 void replxx_set_hint_callback(replxx_hint_callback_t* fn) {
 	setup.hintCallback = fn;
+}
+
+void replxx_set_ud_hint_callback(replxx_ud_hint_callback_t* fn, void* user_data) {
+	setup.udHintCallback = fn;
+	setup.hintUserdata = user_data;
 }
 
 void replxx_add_hint(replxx_hints* lh, const char* str) {

--- a/src/setup.hxx
+++ b/src/setup.hxx
@@ -16,9 +16,17 @@ struct Setup {
 	bool beepOnAmbiguousCompletion;
 	bool noColor;
 	replxx_completion_callback_t* completionCallback;
+	replxx_ud_completion_callback_t* udCompletionCallback;
 	replxx_ctx_completion_callback_t* ctxCompletionCallback;
+	replxx_ud_ctx_completion_callback_t* udCtxCompletionCallback;
 	replxx_highlighter_callback_t* highlighterCallback;
+	replxx_ud_highlighter_callback_t* udHighlighterCallback;
 	replxx_hint_callback_t* hintCallback;
+	replxx_ud_hint_callback_t* udHintCallback;
+   void* completionUserdata;
+   void* ctxCompletionUserdata;
+   void* highlighterUserdata;
+   void* hintUserdata;
 	Setup( void );
 };
 


### PR DESCRIPTION
- the user data is passed in in the setter method for the callback and then
passed unmodified to the callback during invocation.
- added versions of the completion callbacks which pass through an opaque user
data so the callback can have some context.
- added user data enabled versioin of the hint callback
- added user data enabled versioin of the highlither callback