### PR TITLE
Update the c++ api example to use c++11 library features.

### DIFF
--- a/examples/cxx-api.cxx
+++ b/examples/cxx-api.cxx
@@ -1,80 +1,264 @@
-#include <iostream>
-#include <iomanip>
-#include <cstring>
+#include <regex>
+#include <string>
+#include <vector>
 #include <cctype>
+#include <utility>
+#include <iomanip>
+#include <iostream>
 
 #include "replxx.hxx"
+using Replxx = replxx::Replxx;
 
-using namespace std;
-using namespace replxx;
+// prototypes
+Replxx::completions_t hook_completion(std::string const& context, int index, void* user_data);
+Replxx::hints_t hook_hint(std::string const& context, int index, Replxx::Color& color, void* user_data);
+void hook_color(std::string const& str, Replxx::colors_t& colors, void* user_data);
 
-Replxx::completions_t completionHook( std::string const& prefix, int, void* ud ) {
-	char** examples( static_cast<char**>( ud ) );
+Replxx::completions_t hook_completion(std::string const& context, int index, void* user_data) {
+	auto* examples = static_cast<std::vector<std::string>*>(user_data);
 	Replxx::completions_t completions;
-	for ( int i = 0; examples[i] != NULL; ++i) {
-		if ( strncmp( prefix.c_str(), examples[i], prefix.length() ) == 0 ) {
-			completions.push_back( examples[i] );
+
+	std::string prefix {context.substr(index)};
+	for (auto const& e : *examples) {
+		if (e.compare(0, prefix.size(), prefix) == 0) {
+			completions.emplace_back(e.c_str());
 		}
 	}
-	return ( completions );
+
+	return completions;
 }
 
-Replxx::hints_t hintHook( std::string const& prefix, int, Replxx::Color&, void* ud ) {
-	char** examples( static_cast<char**>( ud ) );
+Replxx::hints_t hook_hint(std::string const& context, int index, Replxx::Color& color, void* user_data) {
+	auto* examples = static_cast<std::vector<std::string>*>(user_data);
 	Replxx::hints_t hints;
-	for ( int i = 0;	examples[i] != NULL; ++i) {
-		if ( strncmp( prefix.c_str(), examples[i], prefix.length() ) == 0 ) {
-			hints.push_back( examples[i] + prefix.length() );
-		}
-	}
-	return ( hints );
-}
 
-void colorHook( std::string const& str_, Replxx::colors_t& colors_, void* ) {
-	for ( int i( 0 ); i < static_cast<int>( str_.length() ); ++ i ) {
-		if ( isdigit( str_[i] ) ) {
-			colors_[i] = Replxx::Color::BRIGHTMAGENTA;
-		}
-	}
-}
-
-int main ( int, char** ) {
-	const char* examples[] = {
-		"db", "hello", "hallo", "hans", "hansekogge", "seamann", "quetzalcoatl", "quit", "power", NULL
-	};
-	Replxx replxx;
-	replxx.install_window_change_handler();
-
-	const char* file = "./history";
-
-	replxx.history_load( file );
-	replxx.set_completion_callback( completionHook, examples );
-	replxx.set_highlighter_callback( colorHook, nullptr );
-	replxx.set_hint_callback( hintHook, examples );
-
-	printf("starting...\n");
-
-	char const* prompt = "\x1b[1;32mreplxx\x1b[0m> ";
-
-	while ( true ) {
-		char const* result = replxx.input( prompt );
-
-		if (result == NULL) {
-			printf("\n");
-			break;
-		} else if (!strncmp(result, "/history", 8)) {
-			/* Display the current history. */
-			for ( int index = 0, size = replxx.history_size(); index < size; ++index ) {
-				cout << setw( 4 ) << index << ": " << replxx.history_line( index ) << endl;
+	// only show hint if prefix is at least 'n' chars long
+	// or if prefix begins with a specific character
+	std::string prefix {context.substr(index)};
+	if (prefix.size() >= 2 || (! prefix.empty() && prefix.at(0) == '.')) {
+		for (auto const& e : *examples) {
+			if (e.compare(0, prefix.size(), prefix) == 0) {
+				hints.emplace_back(e.substr(prefix.size()).c_str());
 			}
 		}
-		if (*result == '\0') {
+	}
+
+	// set hint color to green if single match found
+	if (hints.size() == 1) {
+		color = Replxx::Color::GREEN;
+	}
+
+	return hints;
+}
+
+void hook_color(std::string const& context, Replxx::colors_t& colors, void* user_data) {
+	auto* regex_color = static_cast<std::vector<std::pair<std::string, Replxx::Color>>*>(user_data);
+
+	// highlight matching regex sequences
+	for (auto const& e : *regex_color) {
+		size_t pos {0};
+		std::string str = context;
+		std::smatch match;
+
+		while(std::regex_search(str, match, std::regex(e.first))) {
+			std::string c {match[0]};
+			pos += std::string(match.prefix()).size();
+
+			for (size_t i = 0; i < c.size(); ++i) {
+				colors.at(pos + i) = e.second;
+			}
+
+			pos += c.size();
+			str = match.suffix();
+		}
+	}
+}
+
+int main() {
+	// words to be completed
+	std::vector<std::string> examples {
+		".help", ".history", ".quit", ".exit", ".clear", ".prompt ",
+		"hello", "world", "db", "data", "drive", "print", "put",
+		"color_black", "color_red", "color_green", "color_brown", "color_blue",
+		"color_magenta", "color_cyan", "color_lightgray", "color_gray",
+		"color_brightred", "color_brightgreen", "color_yellow", "color_brightblue",
+		"color_brightmagenta", "color_brightcyan", "color_white", "color_normal",
+	};
+
+	// highlight specific words
+	// a regex string, and a color
+	// the order matters, the last match will take precedence
+	using cl = Replxx::Color;
+	std::vector<std::pair<std::string, cl>> regex_color {
+		// single chars
+		{"\\`", cl::BRIGHTCYAN},
+		{"\\'", cl::BRIGHTBLUE},
+		{"\\\"", cl::BRIGHTBLUE},
+		{"\\-", cl::BRIGHTBLUE},
+		{"\\+", cl::BRIGHTBLUE},
+		{"\\=", cl::BRIGHTBLUE},
+		{"\\/", cl::BRIGHTBLUE},
+		{"\\*", cl::BRIGHTBLUE},
+		{"\\^", cl::BRIGHTBLUE},
+		{"\\.", cl::BRIGHTMAGENTA},
+		{"\\(", cl::BRIGHTMAGENTA},
+		{"\\)", cl::BRIGHTMAGENTA},
+		{"\\[", cl::BRIGHTMAGENTA},
+		{"\\]", cl::BRIGHTMAGENTA},
+		{"\\{", cl::BRIGHTMAGENTA},
+		{"\\}", cl::BRIGHTMAGENTA},
+
+		// color keywords
+		{"color_black", cl::BLACK},
+		{"color_red", cl::RED},
+		{"color_green", cl::GREEN},
+		{"color_brown", cl::BROWN},
+		{"color_blue", cl::BLUE},
+		{"color_magenta", cl::MAGENTA},
+		{"color_cyan", cl::CYAN},
+		{"color_lightgray", cl::LIGHTGRAY},
+		{"color_gray", cl::GRAY},
+		{"color_brightred", cl::BRIGHTRED},
+		{"color_brightgreen", cl::BRIGHTGREEN},
+		{"color_yellow", cl::YELLOW},
+		{"color_brightblue", cl::BRIGHTBLUE},
+		{"color_brightmagenta", cl::BRIGHTMAGENTA},
+		{"color_brightcyan", cl::BRIGHTCYAN},
+		{"color_white", cl::WHITE},
+		{"color_normal", cl::NORMAL},
+
+		// commands
+		{"\\.help", cl::BRIGHTMAGENTA},
+		{"\\.history", cl::BRIGHTMAGENTA},
+		{"\\.quit", cl::BRIGHTMAGENTA},
+		{"\\.exit", cl::BRIGHTMAGENTA},
+		{"\\.clear", cl::BRIGHTMAGENTA},
+		{"\\.prompt", cl::BRIGHTMAGENTA},
+
+		// numbers
+		{"[\\-|+]{0,1}[0-9]+", cl::YELLOW}, // integers
+		{"[\\-|+]{0,1}[0-9]*\\.[0-9]+", cl::YELLOW}, // decimals
+		{"[\\-|+]{0,1}[0-9]+e[\\-|+]{0,1}[0-9]+", cl::YELLOW}, // scientific notation
+
+		// strings
+		{"\".*?\"", cl::BRIGHTGREEN}, // double quotes
+		{"\'.*?\'", cl::BRIGHTGREEN}, // single quotes
+	};
+
+	// init the repl
+	Replxx rx;
+	rx.install_window_change_handler();
+
+	// the path to the history file
+	std::string history_file {"./replxx_history.txt"};
+
+	// load the history file if it exists
+	rx.history_load(history_file);
+
+	// set the max history size
+	rx.set_max_history_size(12);
+
+	// set the max input line size
+	rx.set_max_line_size(128);
+
+	// set the max number of hint rows to show
+	rx.set_max_hint_rows(8);
+
+	// set the callbacks
+	rx.set_completion_callback(hook_completion, static_cast<void*>(&examples));
+	rx.set_highlighter_callback(hook_color, static_cast<void*>(&regex_color));
+	rx.set_hint_callback(hook_hint, static_cast<void*>(&examples));
+
+	// display initial welcome message
+	std::cout
+	<< "Welcome to Replxx\n"
+	<< "Press 'tab' to view autocompletions\n"
+	<< "Type '.help' for help\n"
+	<< "Type '.quit' or '.exit' to exit\n\n";
+
+	// set the repl prompt
+	std::string prompt {"\x1b[1;32mreplxx\x1b[0m> "};
+
+	// main repl loop
+	for (;;) {
+		// display the prompt and retrieve input from the user
+		char const* cinput = rx.input(prompt);
+
+		if (cinput == nullptr) {
+			// reached EOF
+
+			std::cout << "\n";
 			break;
 		}
 
-		cout << "thanks for the input: " << result << endl;
-		replxx.history_add( result );
-	}
-	replxx.history_save( file );
-}
+		// change cinput into a std::string
+		// easier to manipulate
+		std::string input {cinput};
 
+		if (input.empty()) {
+			// user hit enter on an empty line
+
+			continue;
+
+		} else if (input.compare(0, 5, ".quit") == 0 || input.compare(0, 5, ".exit") == 0) {
+			// exit the repl
+
+			rx.history_add(input);
+			break;
+
+		} else if (input.compare(0, 5, ".help") == 0) {
+			// display the help output
+			std::cout
+			<< ".help\n\tdisplays the help output\n"
+			<< ".quit\n\texit the repl\n"
+			<< ".exit\n\texit the repl\n"
+			<< ".clear\n\tclears the screen\n"
+			<< ".history\n\tdisplays the history output\n"
+			<< ".prompt <str>\n\tset the repl prompt to <str>\n";
+
+			rx.history_add(input);
+			continue;
+
+		} else if (input.compare(0, 7, ".prompt") == 0) {
+			// set the repl prompt text
+			auto pos = input.find(" ");
+			if (pos == std::string::npos) {
+				std::cout << "Error: '.prompt' missing argument\n";
+			} else {
+				prompt = input.substr(pos + 1) + " ";
+			}
+
+			rx.history_add(input);
+			continue;
+
+		} else if (input.compare(0, 8, ".history") == 0) {
+			// display the current history
+			for (size_t i = 0, sz = rx.history_size(); i < sz; ++i) {
+				std::cout << std::setw(4) << i << ": " << rx.history_line(i) << "\n";
+			}
+
+			rx.history_add(input);
+			continue;
+
+		} else if (input.compare(0, 6, ".clear") == 0) {
+			// clear the screen
+			rx.clear_screen();
+
+			rx.history_add(input);
+			continue;
+
+		} else {
+			// default action
+			// echo the input
+			std::cout << input << "\n";
+
+			rx.history_add(input);
+			continue;
+		}
+	}
+
+	// save the history
+	rx.history_save(history_file);
+
+	std::cout << "\nExiting Replxx\n";
+}


### PR DESCRIPTION
Hey, great work with the library!

I was playing around with the c++ api example, and adapted most of the c lang specific features to use modern c++11 features.  
The main changes are the following:  
* change `const char*` to `std::string`
* change `const char* []` to `std::vector<std::string>`
* update the hook functions to handle the `std::vector<std::string>` example word list
* update the hook functions for loops to use range-based for loops
* add more example keywords `help` `clear` and `quit` like the `history`keyword
* all output uses iostreams

I'm not sure if these changes are of interest to you, but I thought I would share it.