### PR TITLE
Implement word break escape support

### DIFF
--- a/examples/c-api.c
+++ b/examples/c-api.c
@@ -40,7 +40,7 @@ void colorHook( char const* str_, ReplxxColor* colors_, int size_, void* ud ) {
 
 int main (int argc, char** argv) {
 	const char* examples[] = {
-		"db", "hello", "hallo", "hans", "hansekogge", "seamann", "quetzalcoatl", "quit", "power", NULL
+		"db", "hello", "hallo", "hello\\ world", "hans", "hansekogge", "seamann", "quetzalcoatl", "quit", "power", NULL
 	};
 	Replxx* replxx = replxx_init();
 	replxx_install_window_change_handler( replxx );
@@ -60,6 +60,8 @@ int main (int argc, char** argv) {
 	replxx_set_completion_callback( replxx, completionHook, examples );
 	replxx_set_highlighter_callback( replxx, colorHook, NULL );
 	replxx_set_hint_callback( replxx, hintHook, examples );
+	replxx_set_word_break_characters( replxx, " " );
+	replxx_set_escape_characters( replxx, "\\" );
 
 	printf("starting...\n");
 

--- a/examples/cxx-api.cxx
+++ b/examples/cxx-api.cxx
@@ -79,6 +79,7 @@ int main() {
 	std::vector<std::string> examples {
 		".help", ".history", ".quit", ".exit", ".clear", ".prompt ",
 		"hello", "world", "db", "data", "drive", "print", "put",
+		"hello\\ world", "welcome\\ to\\ replxx",
 		"color_black", "color_red", "color_green", "color_brown", "color_blue",
 		"color_magenta", "color_cyan", "color_lightgray", "color_gray",
 		"color_brightred", "color_brightgreen", "color_yellow", "color_brightblue",
@@ -168,6 +169,8 @@ int main() {
 	rx.set_completion_callback(hook_completion, static_cast<void*>(&examples));
 	rx.set_highlighter_callback(hook_color, static_cast<void*>(&regex_color));
 	rx.set_hint_callback(hook_hint, static_cast<void*>(&examples));
+	rx.set_word_break_characters(" ");
+	rx.set_escape_characters("\\");
 
 	// display initial welcome message
 	std::cout

--- a/include/replxx.h
+++ b/include/replxx.h
@@ -210,6 +210,15 @@ int replxx_history_size( Replxx* );
  */
 void replxx_set_word_break_characters( Replxx*, char const* wordBreakers );
 
+/*! \brief Set escape characters.
+ *
+ * This setting influences \e breakPos in completion and hints callbacks
+ * and how completions are printed.
+ *
+ * \param escapeChars - 7-bit ASCII set of word breaking characters.
+ */
+void replxx_set_escape_characters( Replxx*, char const* escapeChars );
+
 /*! \brief Set special prefixes.
  *
  * Special prefixes are word breaking characters

--- a/include/replxx.hxx
+++ b/include/replxx.hxx
@@ -181,6 +181,15 @@ public:
 	 */
 	void set_word_break_characters( char const* wordBreakers );
 
+	/*! \brief Set escape characters.
+	 *
+	 * This setting influences \e breakPos in completion and hints callbacks
+	 * and how completions are printed.
+	 *
+	 * \param escapeChars - 7-bit ASCII set of escape characters.
+	 */
+	void set_escape_characters( char const* escapeChars );
+
 	/*! \brief Set special prefixes.
 	 *
 	 * Special prefixes are word breaking characters

--- a/src/inputbuffer.cxx
+++ b/src/inputbuffer.cxx
@@ -347,7 +347,9 @@ int InputBuffer::start_index() {
 	int startIndex = _pos;
 	while (--startIndex >= 0) {
 		if ( strchr(_replxx.break_chars(), _buf32[startIndex]) ) {
-			break;
+			if ( strchr(_replxx.escape_chars(), _buf32[startIndex - 1]) == nullptr ) {
+				break;
+			}
 		}
 	}
 	if ( ( startIndex < 0 ) || ! strchr( _replxx.special_prefixes(), _buf32[startIndex] ) ) {

--- a/src/replxx.cxx
+++ b/src/replxx.cxx
@@ -179,6 +179,7 @@ Replxx::ReplxxImpl::ReplxxImpl( FILE*, FILE*, FILE* )
 	, _killRing()
 	, _maxHintRows( REPLXX_MAX_HINT_ROWS )
 	, _breakChars( defaultBreakChars )
+	, _escapeChars ( "" )
 	, _specialPrefixes( "" )
 	, _completionCountCutoff( 100 )
 	, _doubleTabCompletion( false )
@@ -419,6 +420,10 @@ void Replxx::ReplxxImpl::set_word_break_characters( char const* wordBreakers ) {
 	_breakChars = wordBreakers;
 }
 
+void Replxx::ReplxxImpl::set_escape_characters( const char* escapeChars ) {
+	_escapeChars = escapeChars;
+}
+
 void Replxx::ReplxxImpl::set_special_prefixes( char const* specialPrefixes ) {
 	_specialPrefixes = specialPrefixes;
 }
@@ -504,6 +509,10 @@ void Replxx::set_preload_buffer( std::string const& preloadText ) {
 
 void Replxx::set_word_break_characters( char const* wordBreakers ) {
 	_impl->set_word_break_characters( wordBreakers );
+}
+
+void Replxx::set_escape_characters( char const* escapeChars ) {
+	_impl->set_escape_characters( escapeChars );
 }
 
 void Replxx::set_special_prefixes( char const* specialPrefixes ) {
@@ -703,6 +712,11 @@ void replxx_set_max_hint_rows( ::Replxx* replxx_, int count ) {
 void replxx_set_word_break_characters( ::Replxx* replxx_, char const* breakChars_ ) {
 	replxx::Replxx::ReplxxImpl* replxx( reinterpret_cast<replxx::Replxx::ReplxxImpl*>( replxx_ ) );
 	replxx->set_word_break_characters( breakChars_ );
+}
+
+void replxx_set_escape_characters( ::Replxx* replxx_, char const* escapeChars_ ) {
+	replxx::Replxx::ReplxxImpl* replxx( reinterpret_cast<replxx::Replxx::ReplxxImpl*>( replxx_ ) );
+	replxx->set_escape_characters( escapeChars_ );
 }
 
 void replxx_set_special_prefixes( ::Replxx* replxx_, char const* specialPrefixes_ ) {

--- a/src/replxx_impl.hxx
+++ b/src/replxx_impl.hxx
@@ -54,6 +54,7 @@ private:
 	KillRing _killRing;
 	int _maxHintRows;
 	char const* _breakChars;
+	char const* _escapeChars;
 	char const* _specialPrefixes;
 	int _completionCountCutoff;
 	bool _doubleTabCompletion;
@@ -81,6 +82,7 @@ public:
 	int history_size( void ) const;
 	void set_preload_buffer(std::string const& preloadText);
 	void set_word_break_characters( char const* wordBreakers );
+	void set_escape_characters( char const* escapeChars );
 	void set_special_prefixes( char const* specialPrefixes );
 	void set_max_line_size( int len );
 	void set_max_hint_rows( int count );
@@ -117,6 +119,9 @@ public:
 	}
 	char const* break_chars( void ) const {
 		return ( _breakChars );
+	}
+	char const* escape_chars( void ) const {
+		return ( _escapeChars );
 	}
 	char const* special_prefixes( void ) const {
 		return ( _specialPrefixes );


### PR DESCRIPTION
These are my changes so far. I extended the examples to test them.

The C++ version works really well. The C API seems to have some issues with the break char, not sure why though.

The escape chars are user definable and disabled by default. When not setting escape chars, while still setting word break chars, the behavior is the same as it currently is.