### PR TITLE
Use `unsigned char` for masks

### DIFF
--- a/examples/cxx-api.cxx
+++ b/examples/cxx-api.cxx
@@ -53,9 +53,9 @@ Replxx::hints_t hook_hint(std::string const& context, int index, Replxx::Color& 
 
 int real_len( std::string const& s ) {
 	int len( 0 );
-	char m4( 128 + 64 + 32 + 16 );
-	char m3( 128 + 64 + 32 );
-	char m2( 128 + 64 );
+	unsigned char m4( 128 + 64 + 32 + 16 );
+	unsigned char m3( 128 + 64 + 32 );
+	unsigned char m2( 128 + 64 );
 	for ( int i( 0 ); i < static_cast<int>( s.length() ); ++ i, ++ len ) {
 		char c( s[i] );
 		if ( ( c & m4 ) == m4 ) {


### PR DESCRIPTION
Prevents compiler warning / error about negative value being wrapped.