### PR TITLE
Prevent compilation failure due to digraph.

### DIFF
--- a/src/replxx.cxx
+++ b/src/replxx.cxx
@@ -561,7 +561,7 @@ int Replxx::print( char const* format_, ... ) {
 }
 
 ::Replxx* replxx_init() {
-	return ( reinterpret_cast<::Replxx*>( new replxx::Replxx::ReplxxImpl( nullptr, nullptr, nullptr ) ) );
+	return ( reinterpret_cast< ::Replxx*>( new replxx::Replxx::ReplxxImpl( nullptr, nullptr, nullptr ) ) );
 }
 
 void replxx_end( ::Replxx* replxx_ ) {


### PR DESCRIPTION
The character sequence <: was mistakenly interpreted as a digraph by some older C++ compilers.
I simply inserted a space between the < and the :: in a reinterpret cast, to prevent compilation failure on older compilers.