### PR TITLE
Prevent undefined behavior upon startup

### DIFF
--- a/src/replxx_impl.cxx
+++ b/src/replxx_impl.cxx
@@ -136,8 +136,12 @@ void Replxx::ReplxxImpl::realloc( int len_ ) {
 		input_buffer_t newBuf32(new char32_t[_buflen]);
 		char_widths_t newCharWidths(new char[_buflen]);
 		using std::swap;
-		memcpy( newBuf32.get(), _buf32.get(), sizeof ( char32_t ) * oldBufLen );
-		memcpy( newCharWidths.get(), _charWidths.get(), sizeof ( char ) * oldBufLen );
+		if (_buf32.get()) {
+			memcpy( newBuf32.get(), _buf32.get(), sizeof ( char32_t ) * oldBufLen );
+		}
+		if (_charWidths.get()) {
+			memcpy( newCharWidths.get(), _charWidths.get(), sizeof ( char ) * oldBufLen );
+		}
 		swap( _buf32, newBuf32 );
 		swap( _charWidths, newCharWidths );
 	}


### PR DESCRIPTION
Calling `std::memcpy()` with a `nullptr` source or destination is considered an undefined behavior -- even if the size is actually zero.

Here's how UBSAN warned about that:
```    
replxx/src/replxx_impl.cxx:139:9: runtime error: null pointer passed as argument 2, which is declared to never be null
replxx/src/replxx_impl.cxx:140:9: runtime error: null pointer passed as argument 2, which is declared to never be null
```

Cc: @syyyr