### PR TITLE
count escape as it means processed

### DIFF
--- a/src/windows.cxx
+++ b/src/windows.cxx
@@ -130,7 +130,10 @@ int win_write( char const* str_, int size_ ) {
 							break;
 						}
 					}
-					str_ = s = HandleEsc( str_ + 1, e );
+					s = HandleEsc( str_ + 1, e );
+					int toEscape( s - str_);
+					count += toEscape;
+					str_ = s;
 				} else {
 					++ str_;
 				}


### PR DESCRIPTION
Hi @AmokHuginnsson , when trying example the "write failed" exception raised on windows because escape characters were not counted.