### PR TITLE
fix out_of_range by empty _data when showing completion

### DIFF
--- a/src/replxx_impl.cxx
+++ b/src/replxx_impl.cxx
@@ -766,14 +766,16 @@ int Replxx::ReplxxImpl::completeLine( void ) {
 					int itemLength = static_cast<int>(completions[index].length());
 					fflush(stdout);
 
-					static UnicodeString const col( ansi_color( Replxx::Color::BRIGHTMAGENTA ) );
-					if ( !_noColor ) {
-						write32( col.get(), col.length() );
-					}
-					write32( &_data[_pos - contextLen], longestCommonPrefix );
-					static UnicodeString const res( ansi_color( Replxx::Color::DEFAULT ) );
-					if ( !_noColor ) {
-						write32( res.get(), res.length() );
+					if (longestCommonPrefix) {
+						static UnicodeString const col(ansi_color(Replxx::Color::BRIGHTMAGENTA));
+						if (!_noColor) {
+							write32(col.get(), col.length());
+						}
+						write32(&_data[_pos - contextLen], longestCommonPrefix);
+						static UnicodeString const res(ansi_color(Replxx::Color::DEFAULT));
+						if (!_noColor) {
+							write32(res.get(), res.length());
+						}
 					}
 
 					write32( completions[index].get() + longestCommonPrefix, itemLength - longestCommonPrefix );


### PR DESCRIPTION
There is out of bound access on _data when _data is empty. Fortunately the longestCommonPrefix also zero which leads to no access on empty _data. The DEBUG build version on MSVC enables bound checking in `operator[]` which raised an exception.

related docs: https://docs.microsoft.com/en-us/cpp/standard-library/checked-iterators?view=vs-2017
