### PR TITLE
Fix blocking on skipped console events on Windows.

### DIFF
--- a/src/io.cxx
+++ b/src/io.cxx
@@ -480,7 +480,22 @@ Terminal::EVENT_TYPE Terminal::wait_for_input( void ) {
 	while ( true ) {
 		DWORD event( WaitForMultipleObjects( std::size( handles ), handles, false, INFINITE ) );
 		switch ( event ) {
-			case ( WAIT_OBJECT_0 + 0 ): return ( EVENT_TYPE::KEY_PRESS );
+			case ( WAIT_OBJECT_0 + 0 ): {
+				// peek events that will be skipped
+				INPUT_RECORD rec;
+				DWORD count;
+				PeekConsoleInputW( _consoleIn, &rec, 1, &count );
+
+				if ( rec.EventType != KEY_EVENT ||
+					( !rec.Event.KeyEvent.bKeyDown &&
+					rec.Event.KeyEvent.wVirtualKeyCode != VK_MENU ) ) {
+					// read the event to unsignal the handle
+					ReadConsoleInputW( _consoleIn, &rec, 1, &count );
+					continue;
+				}
+
+				return ( EVENT_TYPE::KEY_PRESS );
+			}
 			case ( WAIT_OBJECT_0 + 1 ): {
 				ResetEvent( _interrupt );
 				if ( _events.empty() ) {


### PR DESCRIPTION
On Windows, current code will complete `Terminal::wait_for_input` with a KEY_PRESS event, even if a skipped event (non-KEY_EVENT or keyup) is currently in the console input buffer.

This leads to blocking on the read call in the `while (true)` loop in `Terminal::read_char`, which will not service asynchronous print message interrupts until an actual key event is triggered.

In this PR, `wait_for_input` is modified to peek/dequeue+skip common events that would get skipped by `read_char` otherwise.