### PR TITLE
Refactor CMake to be more modernized

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,7 @@ configure_package_config_file(
 
 write_basic_package_version_file(
   "${PROJECT_BINARY_DIR}/replxx-config-version.cmake"
-  COMPATIBILITY SameMinorVersion)
+  COMPATIBILITY AnyNewerVersion)
 
 install(TARGETS replxx EXPORT replxx-targets
   RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,12 +47,17 @@ set(is-gnu $<CXX_COMPILER_ID:GNU>)
 
 set(coverage-config $<AND:$<CONFIG:Coverage>,$<OR:${is-gnu},${is-clang}>>)
 
-file(GLOB replxx-sources CONFIGURE_DEPENDS "src/*.cpp" "src/*.cxx")
+set(replxx-source-patterns "src/*.cpp" "src/*.cxx")
 
-add_library(replxx)
+if (CMAKE_VERSION VERSION_GREATER 3.11)
+  list(INSERT replxx-source-patterns 0 CONFIGURE_DEPENDS)
+endif()
+
+file(GLOB replxx-sources ${replxx-source-patterns})
+
+add_library(replxx ${replxx-sources})
 add_library(replxx::replxx ALIAS replxx)
 
-target_sources(replxx PRIVATE ${replxx-sources})
 target_include_directories(replxx
   PUBLIC
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,10 +74,18 @@ target_compile_options(replxx
     $<${coverage-config}:-fno-inline-small-functions>
     $<$<CXX_COMPILER_ID:GNU>:-Wall -Wextra>
     $<$<CXX_COMPILER_ID:GNU>:-Wno-unknown-pragmas>)
+if (CMAKE_VERSION VERSION_GREATER 3.12)
 target_link_options(replxx
   PRIVATE
     $<${coverage-config}:--coverage>
     $<${is-msvc}:/ignore:4099>)
+else()
+# "safest" way prior to 3.13
+target_link_libraries(replxx
+  PRIVATE
+    $<${coverage-config}:--coverage>
+    $<${is-msvc}:/ignore:4099>)
+endif()
 target_link_libraries(replxx PUBLIC Threads::Threads)
 
 set_property(TARGET replxx PROPERTY DEBUG_POSTFIX -d)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,173 +1,155 @@
-# -*- mode: CMAKE; -*-
+cmake_minimum_required(VERSION 3.5)
+project(replxx
+  #  HOMEPAGE_URL "https://github.com/AmokHuginnsson/replxx"
+  #  DESCRIPTION "replxx - Read Evaluate Print Loop library"
+  VERSION 0.0.2
+  LANGUAGES CXX C)
 
-cmake_minimum_required(VERSION 3.0)
-
-project( replxx VERSION 0.0.2 LANGUAGES CXX C )
-
-option(REPLXX_BuildExamples "Build the examples." ON)
-option(BUILD_SHARED_LIBS "Build as a shared library" ON)
-option(BUILD_STATIC_LIBS "Build as a static library" ON)
-
-if (REPLXX_BuildExamples AND NOT BUILD_STATIC_LIBS)
-	set( BUILD_STATIC_LIBS ON )
+if (NOT DEFINED CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 11)
 endif()
 
-set( CMAKE_BINARY_DIR "${CMAKE_SOURCE_DIR}/build" )
-
-if(NOT CMAKE_BUILD_TYPE)
-	set(CMAKE_BUILD_TYPE Release CACHE string "Choose the type of build, options are: None Debug Release RelWithDebInfo MinSizeRel." FORCE)
+if (NOT DEFINED CMAKE_C_STANDARD)
+  set(CMAKE_C_STANDARD 99)
 endif()
-
-message(STATUS "Build mode: ${CMAKE_BUILD_TYPE}")
-
-# INFO
-set(REPLXX_DISPLAY_NAME "replxx")
-set(REPLXX_URL_INFO_ABOUT "https://github.com/AmokHuginnsson/replxx")
-set(REPLXX_CONTACT "amok@codestation.org")
-set(REPLXX_FRIENDLY_STRING "replxx - Read Evaluate Print Loop library")
-
-# compiler options
-if(CMAKE_COMPILER_IS_GNUCXX)
-	message(STATUS "Compiler type GNU: ${CMAKE_CXX_COMPILER}")
-	set(BASE_COMPILER_OPTIONS "-std=c++11 -Wall -Wextra -D_GNU_SOURCE -pthread")
-	set(CMAKE_CXX_FLAGS                "${CMAKE_CXX_FLAGS} ${BASE_COMPILER_OPTIONS}")
-	set(CMAKE_CXX_FLAGS_COVERAGE       "${CMAKE_CXX_FLAGS} ${BASE_COMPILER_OPTIONS} -O0 --coverage -fno-inline -fno-default-inline -fno-inline-small-functions")
-	set(CMAKE_CXX_FLAGS_DEBUG          "${CMAKE_CXX_FLAGS_DEBUG} ${BASE_COMPILER_OPTIONS} -O0 -g -ggdb -g3 -ggdb3")
-	set(CMAKE_CXX_FLAGS_MINSIZEREL     "${CMAKE_CXX_FLAGS_MINSIZEREL} ${BASE_COMPILER_OPTIONS} -Os")
-	set(CMAKE_CXX_FLAGS_RELEASE        "${CMAKE_CXX_FLAGS_RELEASE} ${BASE_COMPILER_OPTIONS} -O3 -fomit-frame-pointer")
-	set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} ${BASE_COMPILER_OPTIONS} -O3 -g")
-	set(CMAKE_C_FLAGS "-std=c99")
-elseif(CMAKE_COMPILER_IS_CLANGCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-	# using regular Clang or AppleClang
-	message(STATUS "Compiler type CLANG: ${CMAKE_CXX_COMPILER}")
-	set(BASE_COMPILER_OPTIONS "-std=c++11 -Wall -Wextra -D_GNU_SOURCE -pthread")
-	set(CMAKE_CXX_FLAGS                "${CMAKE_CXX_FLAGS} ${BASE_COMPILER_OPTIONS}")
-	set(CMAKE_CXX_FLAGS_DEBUG          "${CMAKE_CXX_FLAGS_DEBUG} ${BASE_COMPILER_OPTIONS} -O0 -g")
-	set(CMAKE_CXX_FLAGS_MINSIZEREL     "${CMAKE_CXX_FLAGS_MINSIZEREL} ${BASE_COMPILER_OPTIONS} -Os")
-	set(CMAKE_CXX_FLAGS_RELEASE        "${CMAKE_CXX_FLAGS_RELEASE} ${BASE_COMPILER_OPTIONS} -O3 -fomit-frame-pointer")
-	set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} ${BASE_COMPILER_OPTIONS} -O3 -g")
-	set(CMAKE_C_FLAGS "-std=c99")
-elseif(MSVC)
-	message(STATUS "Compiler type MSVC: ${CMAKE_CXX_COMPILER}")
-	add_definitions("-D_CRT_SECURE_NO_WARNINGS=1")
-
-	set(CMAKE_EXE_LINKER_FLAGS_DEBUG "${CMAKE_EXE_LINKER_FLAGS_DEBUG} /INCREMENTAL:NO /SUBSYSTEM:CONSOLE /LTCG /ignore:4099")
-	set(CMAKE_EXE_LINKER_FLAGS_MINSIZEREL "${CMAKE_EXE_LINKER_FLAGS_MINSIZEREL} /SUBSYSTEM:CONSOLE /ignore:4099")
-	set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} /SUBSYSTEM:CONSOLE /ignore:4099")
-	set(CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO "${CMAKE_EXE_LINKER_FLAGS_RELWITHDEBINFO} /SUBSYSTEM:CONSOLE /ignore:4099")
-else()
-	# unknown compiler
-	message(STATUS "Compiler type UNKNOWN: ${CMAKE_CXX_COMPILER}")
-	set(BASE_COMPILER_OPTIONS "-std=c++11 -Wall -Wextra -pthread")
-	set(CMAKE_CXX_FLAGS                "${CMAKE_CXX_FLAGS} ${BASE_COMPILER_OPTIONS}")
-	set(CMAKE_CXX_FLAGS_DEBUG          "${CMAKE_CXX_FLAGS_DEBUG} ${BASE_COMPILER_OPTIONS} -O0 -g")
-	set(CMAKE_CXX_FLAGS_MINSIZEREL     "${CMAKE_CXX_FLAGS_MINSIZEREL} ${BASE_COMPILER_OPTIONS} -Os")
-	set(CMAKE_CXX_FLAGS_RELEASE        "${CMAKE_CXX_FLAGS_RELEASE} ${BASE_COMPILER_OPTIONS} -O3 -fomit-frame-pointer")
-	set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} ${BASE_COMPILER_OPTIONS} -O3 -g")
-	set(CMAKE_C_FLAGS "-std=c99")
-endif()
-
-# build libreplxx
-set(
-	REPLXX_SOURCES
-	src/conversion.cxx
-	src/ConvertUTF.cpp
-	src/escape.cxx
-	src/history.cxx
-	src/replxx_impl.cxx
-	src/io.cxx
-	src/prompt.cxx
-	src/replxx.cxx
-	src/util.cxx
-	src/wcwidth.cpp
-	src/windows.cxx
-)
 
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS ON)
+
+include(CMakePackageConfigHelpers)
+include(CMakeDependentOption)
 include(GenerateExportHeader)
+include(GNUInstallDirs)
 
-if ( BUILD_STATIC_LIBS )
-	add_library(replxx-static STATIC ${REPLXX_SOURCES})
+find_package(Threads)
 
-	target_include_directories(
-		replxx-static
-		PUBLIC ${PROJECT_SOURCE_DIR}/include
-		PRIVATE ${PROJECT_SOURCE_DIR}/src
-	)
-	generate_export_header(replxx-static)
-	if ( MSVC )
-		set_target_properties( replxx-static PROPERTIES RELEASE_OUTPUT_NAME replxx-static DEBUG_OUTPUT_NAME replxx-static-d )
-		target_compile_definitions(replxx-static PRIVATE REPLXX_STATIC)
-	else ()
-		set_target_properties( replxx-static PROPERTIES RELEASE_OUTPUT_NAME replxx DEBUG_OUTPUT_NAME replxx-d )
-	endif ()
-	set( TARGETS replxx-static )
+cmake_dependent_option(REPLXX_BUILD_EXAMPLES
+  "Build the examples" ON
+  "CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR" OFF)
+cmake_dependent_option(REPLXX_BUILD_PACKAGE
+  "Generate package target" ON
+  "CMAKE_SOURCE_DIR STREQUAL PROJECT_SOURCE_DIR" OFF)
+
+if (NOT CMAKE_BUILD_TYPE)
+  message(AUTHOR_WARNING "CMAKE_BUILD_TYPE not set. Defaulting to Release")
+  set(CMAKE_BUILD_TYPE Release)
 endif()
 
-if ( BUILD_SHARED_LIBS )
-	add_library(replxx SHARED ${REPLXX_SOURCES})
-	add_library(Replxx::Replxx ALIAS replxx)
+# INFO
+set(REPLXX_URL_INFO_ABOUT "https://github.com/AmokHuginnsson/replxx")
+set(REPLXX_DISPLAY_NAME "replxx")
+set(REPLXX_CONTACT "amok@codestation.org")
 
-	target_include_directories(
-		replxx
-		PUBLIC ${PROJECT_SOURCE_DIR}/include
-		PRIVATE ${PROJECT_SOURCE_DIR}/src
-	)
-	generate_export_header(replxx)
-	set_target_properties( replxx PROPERTIES RELEASE_OUTPUT_NAME replxx DEBUG_OUTPUT_NAME replxx-d )
-	set( TARGETS ${TARGETS} replxx )
-	target_compile_definitions(replxx PRIVATE REPLXX_BUILDING_DLL)
-endif()
+set(is-clang $<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>)
+set(is-msvc $<CXX_COMPILER_ID:MSVC>)
+set(is-gnu $<CXX_COMPILER_ID:GNU>)
 
-# install
-if ( MSVC )
-				install( TARGETS ${TARGETS} RUNTIME DESTINATION bin LIBRARY DESTINATION lib ARCHIVE DESTINATION lib )
-else()
-	install( TARGETS ${TARGETS} DESTINATION lib )
-endif()
+set(coverage-config $<AND:$<CONFIG:Coverage>,$<OR:${is-gnu},${is-clang}>>)
+
+file(GLOB replxx-sources CONFIGURE_DEPENDS "src/*.cpp" "src/*.cxx")
+
+add_library(replxx)
+add_library(replxx::replxx ALIAS replxx)
+
+target_sources(replxx PRIVATE ${replxx-sources})
+target_include_directories(replxx
+  PUBLIC
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+  PRIVATE
+    $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/src>)
+target_compile_definitions(replxx
+  PRIVATE
+    $<$<CXX_COMPILER_ID:MSVC>:_CRT_SECURE_NO_WARNINGS=1>
+    $<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:REPLXX_STATIC>
+    $<$<BOOL:${BUILD_SHARED_LIBS}>:REPLXX_BUILDING_DLL>)
+target_compile_options(replxx
+  PRIVATE
+    $<$<AND:$<CONFIG:RelWithDebInfo>,${compiler-id-clang-or-gnu}>:-fomit-frame-pointer>
+    $<$<AND:$<CONFIG:MinSizeRel>,${compiler-id-clang-or-gnu}>:-Os>
+    $<$<AND:$<CONFIG:Debug>,$<CXX_COMPILER_ID:GNU>>:-g -ggdb -g3 -ggdb3>
+    $<${coverage-config}:-O0 --coverage>
+    $<${coverage-config}:-fno-inline -fno-default-inline>
+    $<${coverage-config}:-fno-inline-small-functions>
+    $<$<CXX_COMPILER_ID:GNU>:-Wall -Wextra>
+    $<$<CXX_COMPILER_ID:GNU>:-Wno-unknown-pragmas>)
+target_link_options(replxx
+  PRIVATE
+    $<${coverage-config}:--coverage>
+    $<${is-msvc}:/ignore:4099>)
+target_link_libraries(replxx PUBLIC Threads::Threads)
+
+set_property(TARGET replxx PROPERTY DEBUG_POSTFIX -d)
+generate_export_header(replxx)
+
+configure_package_config_file(
+  "${PROJECT_SOURCE_DIR}/replxx-config.cmake.in"
+  "${PROJECT_BINARY_DIR}/replxx-config.cmake"
+  INSTALL_DESTINATION ${CMAKE_INSTALL_DATADIR}/cmake/replxx
+  NO_CHECK_REQUIRED_COMPONENTS_MACRO
+  NO_SET_AND_CHECK_MACRO)
+
+write_basic_package_version_file(
+  "${PROJECT_BINARY_DIR}/replxx-config-version.cmake"
+  COMPATIBILITY SameMinorVersion)
+
+install(TARGETS replxx EXPORT replxx-targets
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+install(EXPORT replxx-targets
+  NAMESPACE replxx::
+  DESTINATION ${CMAKE_INSTALL_DATADIR}/cmake/replxx)
+
+install(
+  FILES
+    "${PROJECT_BINARY_DIR}/replxx-config-version.cmake"
+    "${PROJECT_BINARY_DIR}/replxx-config.cmake"
+  DESTINATION
+    ${CMAKE_INSTALL_DATADIR}/cmake/replxx)
 
 # headers
-install(FILES include/replxx.hxx include/replxx.h DESTINATION include)
+install(
+  FILES
+    include/replxx.hxx
+    include/replxx.h
+  DESTINATION
+    ${CMAKE_INSTALL_INCLUDEDIR})
 
-if (REPLXX_BuildExamples)
-	# build example
-	add_executable(
-		example-c-api
-		examples/c-api.c
-		examples/util.c
-	)
+if (REPLXX_BUILD_EXAMPLES)
+  add_executable(replxx-example-cxx-api)
+  add_executable(replxx-example-c-api)
 
-	add_executable(
-		example-cxx-api
-		examples/cxx-api.cxx
-		examples/util.c
-	)
+  target_sources(replxx-example-cxx-api
+    PRIVATE
+      examples/cxx-api.cxx
+      examples/util.c)
+  target_sources(replxx-example-c-api
+    PRIVATE
+      examples/c-api.c
+      examples/util.c)
+  target_compile_definitions(replxx-example-cxx-api PRIVATE REPLXX_STATIC)
+  target_compile_definitions(replxx-example-c-api PRIVATE REPLXX_STATIC)
+  target_link_libraries(replxx-example-cxx-api PRIVATE replxx::replxx)
+  target_link_libraries(replxx-example-c-api
+    PRIVATE
+      $<$<CXX_COMPILER_ID:GNU>:stdc++>
+      replxx::replxx)
 
-	target_link_libraries(
-		example-cxx-api
-		PRIVATE replxx-static
-	)
-
-	if ( NOT MSVC )
-		set( CXX_LIB stdc++ )
-	endif()
-
-	if (MSVC)
-		target_compile_definitions(example-cxx-api PRIVATE REPLXX_STATIC)
-		target_compile_definitions(example-c-api PRIVATE REPLXX_STATIC)
-	endif()
-
-	target_link_libraries(
-		example-c-api
-		PRIVATE replxx-static ${CXX_LIB}
-	)
 endif()
 
-# packaging
+if (NOT REPLXX_BUILD_PACKAGE)
+  return()
+endif()
+
 include(CPack)
 
 set(CPACK_SET_DESTDIR ON)
 
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Readline and libedit replacement library")
+set(CPACK_PACKAGE_HOMEPAGE_URL "${REPLXX_URL_INFO_ABOUT}")
 set(CPACK_PACKAGE_VENDOR  "codestation.org")
 set(CPACK_PACKAGE_CONTACT "amok@codestation.org")
 set(CPACK_PACKAGE_VERSION "${PROJECT_VERSION}")
@@ -176,6 +158,4 @@ set(CPACK_RESOURCE_FILE_LICENSE "${PROJECT_SOURCE_DIR}/LICENSE")
 
 set(CPACK_STRIP_FILES "ON")
 
-set(CPACK_PACKAGE_NAME "replxx")
 set(CPACK_DEBIAN_PACKAGE_SECTION "utilities")
-

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,8 +132,8 @@ install(
     ${CMAKE_INSTALL_INCLUDEDIR})
 
 if (REPLXX_BUILD_EXAMPLES)
-  add_executable(replxx-example-cxx-api)
-  add_executable(replxx-example-c-api)
+  add_executable(replxx-example-cxx-api "")
+  add_executable(replxx-example-c-api "")
 
   target_sources(replxx-example-cxx-api
     PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,8 @@ set(is-clang $<OR:$<CXX_COMPILER_ID:Clang>,$<CXX_COMPILER_ID:AppleClang>>)
 set(is-msvc $<CXX_COMPILER_ID:MSVC>)
 set(is-gnu $<CXX_COMPILER_ID:GNU>)
 
+set(compiler-id-clang-or-gnu $<OR:${is-clang},${is-gnu}>)
+
 set(coverage-config $<AND:$<CONFIG:Coverage>,$<OR:${is-gnu},${is-clang}>>)
 
 set(replxx-source-patterns "src/*.cpp" "src/*.cxx")

--- a/replxx-config.cmake.in
+++ b/replxx-config.cmake.in
@@ -1,0 +1,3 @@
+@PACKAGE_INIT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/replxx-targets.cmake")

--- a/tests.py
+++ b/tests.py
@@ -187,8 +187,8 @@ verbosity = None
 
 class ReplxxTests( unittest.TestCase ):
 	_prompt_ = "\033\\[1;32mreplxx\033\\[0m> "
-	_cxxSample_ = "./build/debug/example-cxx-api"
-	_cSample_ = "./build/debug/example-c-api"
+	_cxxSample_ = "./build/replxx-example-cxx-api"
+	_cSample_ = "./build/replxx-example-c-api"
 	_end_ = "\r\nExiting Replxx\r\n"
 	def check_scenario(
 		self_, seq_, expected_,


### PR DESCRIPTION
## Overview
This allows us to close #52 

A few "distribution" changes are needed to upgrade the library to follow CMake's modern approach. The biggest change here is that we set whether replxx is a shared library or not via `BUILD_SHARED_LIBS`. We also have a few dependent options now that become enabled based on whether replxx is being built by itself or as part of a larger project.

Please let me know if you'd like more changes made to fit the previous workflow.

## Changelog

This removes the "you can build both" approach, but this is considered "best practice" by modern standards

Bumped the minimum CMake version to 3.14

Fallback to C++11 if not defined

add_subdirectory usage is now safe

Compiler flags rely on generator expressions

Update options to fit REPLXX_<> naming scheme

Use find_package(Threads) for -pthread support

Add basic find_package config support

Fix potential name clash for examples if built in larger project

Fix install location for various items to fall under GNU Install Dirs