### PR TITLE
Fix compile on newer GCC versions

### DIFF
--- a/src/io.cxx
+++ b/src/io.cxx
@@ -3,6 +3,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <array>
+#include <stdexcept>
 
 #ifdef _WIN32
 


### PR DESCRIPTION
Signed-off-by: Felix Kaechele <felix@kaechele.ca>

Currently replxx doesn't compile on Fedora 32. Noticed while building rspamd which bundles replxx. But it applies to the upstream version as well.

```
/builddir/build/BUILD/rspamd-2.3/contrib/replxx/src/io.cxx: In member function 'void replxx::Terminal::write32(const char32_t*, int)':
/builddir/build/BUILD/rspamd-2.3/contrib/replxx/src/io.cxx:114:14: error: 'runtime_error' is not a member of 'std'
  114 |   throw std::runtime_error( "write failed" );
      |              ^~~~~~~~~~~~~
/builddir/build/BUILD/rspamd-2.3/contrib/replxx/src/io.cxx: In member function 'void replxx::Terminal::write8(const char*, int)':
/builddir/build/BUILD/rspamd-2.3/contrib/replxx/src/io.cxx:126:14: error: 'runtime_error' is not a member of 'std'
  126 |   throw std::runtime_error( "write failed" );
      |              ^~~~~~~~~~~~~
```