### PR TITLE
Add version property to the libray in CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,7 @@ else()
 	)
 endif()
 target_link_libraries(replxx PUBLIC Threads::Threads)
+set_target_properties(replxx PROPERTIES VERSION ${PROJECT_VERSION})
 
 set_property(TARGET replxx PROPERTY DEBUG_POSTFIX -d)
 if ( NOT BUILD_SHARED_LIBS AND MSVC )


### PR DESCRIPTION
The PR adds the version property to the libray in CMake. This is needed on the Linux platform to automatically create the standard symlinks for versioned shared libraries.

My use case for this is so that Yocto Linux is able to build this package and properly split it between its target installed files and development files.