### PR TITLE
make the REPLXX_STATIC and REPLXX_BUILDING_DLL defines public.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,10 +75,11 @@ target_include_directories(
 )
 target_compile_definitions(
 	replxx
-	PRIVATE
-		$<$<CXX_COMPILER_ID:MSVC>:_CRT_SECURE_NO_WARNINGS=1 /ignore:4503>
+	PUBLIC
 		$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:REPLXX_STATIC>
 		$<$<BOOL:${BUILD_SHARED_LIBS}>:REPLXX_BUILDING_DLL>
+	PRIVATE
+		$<$<CXX_COMPILER_ID:MSVC>:_CRT_SECURE_NO_WARNINGS=1 /ignore:4503>
 )
 target_compile_options(
 	replxx


### PR DESCRIPTION
On Win32, __declspec( dllexport ) / __declspec( dllimport ) affects name mangling and will cause link errors if not set properly (replxx.h / replxx.hxx)