### PR TITLE
Add ability to avoid updating current session history after dumping to file

### DIFF
--- a/examples/c-api.c
+++ b/examples/c-api.c
@@ -228,7 +228,7 @@ int main( int argc, char** argv ) {
 			replxx_history_add( replxx, result );
 		}
 	}
-	replxx_history_save( replxx, file );
+	replxx_history_save( replxx, file, 1 /* update */);
 	printf( "Exiting Replxx\n" );
 	replxx_end( replxx );
 }

--- a/examples/cxx-api.cxx
+++ b/examples/cxx-api.cxx
@@ -345,6 +345,7 @@ int main( int argc_, char** argv_ ) {
 
 	// set the repl prompt
 	std::string prompt {"\x1b[1;32mreplxx\x1b[0m> "};
+	bool history_auto_save = false;
 
 	// main repl loop
 	if ( argc_ > 1 ) {
@@ -385,7 +386,9 @@ int main( int argc_, char** argv_ ) {
 				<< ".exit\n\texit the repl\n"
 				<< ".clear\n\tclears the screen\n"
 				<< ".history\n\tdisplays the history output\n"
-				<< ".prompt <str>\n\tset the repl prompt to <str>\n";
+				<< ".prompt <str>\n\tset the repl prompt to <str>\n"
+				<< ".hist_autosave\n\tauto-save history after each command\n"
+			;
 
 			rx.history_add(input);
 			continue;
@@ -425,6 +428,12 @@ int main( int argc_, char** argv_ ) {
 			rx.history_add(input);
 			continue;
 
+		} else if (input.compare(0, 14, ".hist_autosave") == 0) {
+			std::cout << "history auto-save was: " << history_auto_save << "\n";
+			history_auto_save ^= true;
+			rx.history_add(input);
+			continue;
+
 		} else {
 			// default action
 			// echo the input
@@ -432,6 +441,9 @@ int main( int argc_, char** argv_ ) {
 			rx.print( "%s\n", input.c_str() );
 
 			rx.history_add( input );
+			if ( history_auto_save ) {
+				rx.history_save(history_file, false /* reload */);
+			}
 			continue;
 		}
 	}
@@ -440,7 +452,7 @@ int main( int argc_, char** argv_ ) {
 	}
 
 	// save the history
-	rx.history_save(history_file, true /* reload */);
+	rx.history_save(history_file, false /* reload */);
 
 	std::cout << "\nExiting Replxx\n";
 

--- a/examples/cxx-api.cxx
+++ b/examples/cxx-api.cxx
@@ -440,7 +440,7 @@ int main( int argc_, char** argv_ ) {
 	}
 
 	// save the history
-	rx.history_save(history_file);
+	rx.history_save(history_file, true /* reload */);
 
 	std::cout << "\nExiting Replxx\n";
 

--- a/include/replxx.h
+++ b/include/replxx.h
@@ -504,9 +504,10 @@ REPLXX_IMPEXP int replxx_history_scan_next( Replxx*, ReplxxHistoryScan*, ReplxxH
 /*! \brief Save REPL's history into given file.
  *
  * \param filename - a path to the file where REPL's history should be saved.
+ * \param update - add new history items from history file into the current session.
  * \return 0 iff history file was successfully created, -1 otherwise.
  */
-REPLXX_IMPEXP int replxx_history_save( Replxx*, const char* filename );
+REPLXX_IMPEXP int replxx_history_save( Replxx*, const char* filename, int update );
 
 /*! \brief Load REPL's history from given file.
  *

--- a/include/replxx.hxx
+++ b/include/replxx.hxx
@@ -474,9 +474,10 @@ public:
 	/*! \brief Save REPL's history into given file.
 	 *
 	 * \param filename - a path to the file where REPL's history should be saved.
+	 * \param update - add new history items from history file into the current session.
 	 * \return True iff history file was successfully created.
 	 */
-	bool history_save( std::string const& filename );
+	bool history_save( std::string const& filename, bool update );
 
 	/*! \brief Load REPL's history from given file.
 	 *

--- a/src/history.hxx
+++ b/src/history.hxx
@@ -70,13 +70,13 @@ private:
 public:
 	History( void );
 	void add( UnicodeString const& line, std::string const& when = now_ms_str() );
-	bool save( std::string const& filename );
+	bool save( std::string const& filename, bool update );
 	bool load( std::string const& filename );
 	void clear( void );
 	void set_max_size( int len );
 	void set_unique( bool unique_ ) {
 		_unique = unique_;
-		remove_duplicates();
+		remove_duplicates( _entries, _locations );
 	}
 	void reset_yank_iterator();
 	bool next_yank_position( void );
@@ -114,12 +114,12 @@ private:
 	bool move( entries_t::const_iterator&, int, bool = false ) const;
 	entries_t::const_iterator moved( entries_t::const_iterator, int, bool = false ) const;
 	void erase( entries_t::const_iterator );
-	void trim_to_max_size( void );
+	void trim_to_max_size( entries_t& entries );
 	void remove_duplicate( UnicodeString const& );
-	void remove_duplicates( void );
-	bool do_load( std::string const& );
+	void remove_duplicates( entries_t& entries, locations_t& locations );
+	bool do_load( std::string const&, entries_t& entries );
 	entries_t::const_iterator last( void ) const;
-	void sort( void );
+	void sort( entries_t& entries, locations_t& locations );
 };
 
 class Replxx::HistoryScanImpl {

--- a/src/replxx.cxx
+++ b/src/replxx.cxx
@@ -155,8 +155,8 @@ void Replxx::history_add( std::string const& line ) {
 	_impl->history_add( line );
 }
 
-bool Replxx::history_save( std::string const& filename ) {
-	return ( _impl->history_save( filename ) );
+bool Replxx::history_save( std::string const& filename, bool update ) {
+	return ( _impl->history_save( filename, update ) );
 }
 
 bool Replxx::history_load( std::string const& filename ) {
@@ -557,9 +557,9 @@ int replxx_history_scan_next( ::Replxx*, ReplxxHistoryScan* historyScan_, Replxx
 
 /* Save the history in the specified file. On success 0 is returned
  * otherwise -1 is returned. */
-int replxx_history_save( ::Replxx* replxx_, const char* filename ) {
+int replxx_history_save( ::Replxx* replxx_, const char* filename, int update ) {
 	replxx::Replxx::ReplxxImpl* replxx( reinterpret_cast<replxx::Replxx::ReplxxImpl*>( replxx_ ) );
-	return ( replxx->history_save( filename ) ? 0 : -1 );
+	return ( replxx->history_save( filename, update ) ? 0 : -1 );
 }
 
 /* Load the history from the specified file. If the file does not exist

--- a/src/replxx_impl.cxx
+++ b/src/replxx_impl.cxx
@@ -2068,8 +2068,8 @@ void Replxx::ReplxxImpl::history_add( std::string const& line ) {
 	_history.add( UnicodeString( line ) );
 }
 
-bool Replxx::ReplxxImpl::history_save( std::string const& filename ) {
-	return ( _history.save( filename ) );
+bool Replxx::ReplxxImpl::history_save( std::string const& filename, bool update ) {
+	return ( _history.save( filename, update ) );
 }
 
 bool Replxx::ReplxxImpl::history_load( std::string const& filename ) {

--- a/src/replxx_impl.hxx
+++ b/src/replxx_impl.hxx
@@ -155,7 +155,7 @@ public:
 	void set_hint_callback( Replxx::hint_callback_t const& fn );
 	char const* input( std::string const& prompt );
 	void history_add( std::string const& line );
-	bool history_save( std::string const& filename );
+	bool history_save( std::string const& filename, bool update );
 	bool history_load( std::string const& filename );
 	void history_clear( void );
 	Replxx::HistoryScan::impl_t history_scan( void ) const;


### PR DESCRIPTION
Before this patch replxx, while saving to the history file always reload
the history from the disk and add new items from that file into the
current session. This looks incovenient, if user code calls
history_save() after each command (to save history ASAP, example of such
program is clickhouse-client) since if you run two programs with replxx
completion the completion will overlaps after each command.

Looks like at least this should be configurable.