### PR TITLE
Espose the internal print which accepts a char const* and length via a write method

### DIFF
--- a/include/replxx.h
+++ b/include/replxx.h
@@ -389,6 +389,16 @@ REPLXX_IMPEXP void replxx_set_state( Replxx*, ReplxxState* state );
  */
 REPLXX_IMPEXP int replxx_print( Replxx*, char const* fmt, ... );
 
+/*! \brief Prints a char array with the given length to standard output.
+ *
+ * \copydetails print
+ *
+ * \param str - The char array to print.
+ *
+ * \param length - The length of the array.
+ */
+REPLXX_IMPEXP int replxx_write( char const* str, size_t length );
+
 /*! \brief Schedule an emulated key press event.
  *
  * \param code - key press code to be emulated.

--- a/include/replxx.hxx
+++ b/include/replxx.hxx
@@ -434,6 +434,16 @@ public:
 	 */
 	void print( char const* fmt, ... );
 
+	/*! \brief Prints a char array with the given length to standard output.
+	 *
+	 * \copydetails print
+	 *
+	 * \param str - The char array to print.
+	 *
+	 * \param length - The length of the array.
+	 */
+	void write( char const* str, std::size_t length );
+
 	/*! \brief Schedule an emulated key press event.
 	 *
 	 * \param code - key press code to be emulated.

--- a/src/replxx.cxx
+++ b/src/replxx.cxx
@@ -275,6 +275,11 @@ void Replxx::print( char const* format_, ... ) {
 	return ( _impl->print( buf.get(), size ) );
 }
 
+void Replxx::write( char const* str, std::size_t length )
+{
+	return ( _impl->print( str, length ) );
+}
+
 }
 
 ::Replxx* replxx_init() {
@@ -376,6 +381,16 @@ int replxx_print( ::Replxx* replxx_, char const* format_, ... ) {
 		return ( -1 );
 	}
 	return ( size );
+}
+
+int replxx_write( ::Replxx* replxx_, char const* str, std::size_t length ) {
+	replxx::Replxx::ReplxxImpl* replxx( reinterpret_cast<replxx::Replxx::ReplxxImpl*>( replxx_ ) );
+	try {
+		replxx->print( str, length );
+	} catch ( ... ) {
+		return ( -1 );
+	}
+	return static_cast<int>( length );
 }
 
 struct replxx_completions {


### PR DESCRIPTION
This makes it possible to print a `std::string_view` directly