### PR TITLE
Changed Replxx::ReplxxImpl::_breakChars to std::string

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ libreplxx.a
 history.txt
 *.o
 *~
+.vs

--- a/include/replxx.h
+++ b/include/replxx.h
@@ -396,7 +396,7 @@ REPLXX_IMPEXP int replxx_print( Replxx*, char const* fmt, ... );
  * \param str - The char array to print.
  * \param length - The length of the array.
  */
-REPLXX_IMPEXP int replxx_write( char const* str, int length );
+REPLXX_IMPEXP int replxx_write( Replxx*, char const* str, int length );
 
 /*! \brief Schedule an emulated key press event.
  *

--- a/src/replxx_impl.cxx
+++ b/src/replxx_impl.cxx
@@ -2059,7 +2059,7 @@ Replxx::ACTION_RESULT Replxx::ReplxxImpl::bracketed_paste( char32_t ) {
 bool Replxx::ReplxxImpl::is_word_break_character( char32_t char_ ) const {
 	bool wbc( false );
 	if ( char_ < 128 ) {
-		wbc = strchr( _breakChars, static_cast<char>( char_ ) ) != nullptr;
+		wbc = strchr( _breakChars.c_str(), static_cast<char>( char_ ) ) != nullptr;
 	}
 	return ( wbc );
 }

--- a/src/replxx_impl.hxx
+++ b/src/replxx_impl.hxx
@@ -118,7 +118,7 @@ private:
 	int _lastYankSize;
 	int _maxHintRows;
 	int _hintDelay;
-	char const* _breakChars;
+	std::string _breakChars;
 	int _completionCountCutoff;
 	bool _overwrite;
 	bool _doubleTabCompletion;

--- a/src/utf8string.hxx
+++ b/src/utf8string.hxx
@@ -50,6 +50,7 @@ public:
 	void assign( std::string const& str_ ) {
 		realloc( str_.length() );
 		strncpy( _data.get(), str_.c_str(), str_.length() );
+		_len = str_.length();
 	}
 
 	char const* get() const {


### PR DESCRIPTION
Changed Replxx::ReplxxImpl::_breakChars to std::string to easily store a copy of the word break chars passed not the actual const char* pointer since not always this pointer will be to a string literal.

This is related to https://github.com/AmokHuginnsson/replxx/issues/90.