### PR TITLE
Fix container-overflow in Replxx::ReplxxImpl::incremental_history_search()

### DIFF
--- a/src/replxx_impl.cxx
+++ b/src/replxx_impl.cxx
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <memory>
 #include <cerrno>
+#include <cassert>
 #include <iostream>
 #include <chrono>
 
@@ -2029,6 +2030,7 @@ Replxx::ACTION_RESULT Replxx::ReplxxImpl::incremental_history_search( char32_t s
 					activeHistoryLine.assign( _history.current() );
 					lineSearchPos = ( dp._direction > 0 ) ? 0 : ( activeHistoryLine.length() - dp._searchText.length() );
 				} else {
+					historyLinePosition = 0;
 					beep();
 					break;
 				}
@@ -2209,6 +2211,8 @@ void Replxx::ReplxxImpl::set_no_color( bool val ) {
  * @param pos   current cursor position within the buffer (0 <= pos <= len)
  */
 void Replxx::ReplxxImpl::dynamicRefresh(Prompt& pi, char32_t* buf32, int len, int pos) {
+	assert(pos >= 0 && pos <= len);
+
 	clear_self_to_end_of_screen( &pi );
 	// calculate the position of the end of the prompt
 	int xEndOfPrompt, yEndOfPrompt;


### PR DESCRIPTION
In case of text was found in some history line, but wasn't found in subsequent
search, the historyLinePosition should be reseted, otherwise it will be passed
to dynamicRefresh() and triggers container-overflow.

See-also: https://github.com/ClickHouse-Extras/replxx/pull/16