### PR TITLE
Implement std::istream/ostream overloads for history load and save

### DIFF
--- a/include/replxx.hxx
+++ b/include/replxx.hxx
@@ -35,6 +35,7 @@
 #include <vector>
 #include <string>
 #include <functional>
+#include <iosfwd>
 
 /*
  * For use in Windows DLLs:
@@ -518,12 +519,22 @@ public:
 	 */
 	bool history_save( std::string const& filename );
 
+	/*!
+	* \copydoc history_sync
+	*/
+	void history_save( std::ostream& out );
+
 	/*! \brief Load REPL's history from given file.
 	 *
 	 * \param filename - a path to the file which contains REPL's history that should be loaded.
 	 * \return True iff history file was successfully opened.
 	 */
 	bool history_load( std::string const& filename );
+
+	/*!
+	* \copydoc history_sync
+	*/
+	void history_load( std::istream& in );
 
 	/*! \brief Clear REPL's in-memory history.
 	 */

--- a/src/history.hxx
+++ b/src/history.hxx
@@ -71,7 +71,9 @@ public:
 	History( void );
 	void add( UnicodeString const& line, std::string const& when = now_ms_str() );
 	bool save( std::string const& filename, bool );
+	void save( std::ostream& histFile );
 	bool load( std::string const& filename );
+	void load( std::istream& histFile );
 	void clear( void );
 	void set_max_size( int len );
 	void set_unique( bool unique_ ) {
@@ -117,7 +119,7 @@ private:
 	void trim_to_max_size( void );
 	void remove_duplicate( UnicodeString const& );
 	void remove_duplicates( void );
-	bool do_load( std::string const& );
+	void do_load( std::istream& );
 	entries_t::const_iterator last( void ) const;
 	void sort( void );
 	void reset_iters( void );

--- a/src/replxx.cxx
+++ b/src/replxx.cxx
@@ -162,8 +162,16 @@ bool Replxx::history_save( std::string const& filename ) {
 	return ( _impl->history_save( filename ) );
 }
 
+void Replxx::history_save( std::ostream& out ) {
+	_impl->history_save( out );
+}
+
 bool Replxx::history_load( std::string const& filename ) {
 	return ( _impl->history_load( filename ) );
+}
+
+void Replxx::history_load( std::istream& in ) {
+	_impl->history_load( in );
 }
 
 void Replxx::history_clear( void ) {

--- a/src/replxx_impl.cxx
+++ b/src/replxx_impl.cxx
@@ -2106,12 +2106,20 @@ bool Replxx::ReplxxImpl::history_save( std::string const& filename ) {
 	return ( _history.save( filename, false ) );
 }
 
+void Replxx::ReplxxImpl::history_save( std::ostream& out ) {
+	_history.save( out );
+}
+
 bool Replxx::ReplxxImpl::history_sync( std::string const& filename ) {
 	return ( _history.save( filename, true ) );
 }
 
 bool Replxx::ReplxxImpl::history_load( std::string const& filename ) {
 	return ( _history.load( filename ) );
+}
+
+void Replxx::ReplxxImpl::history_load( std::istream& in ) {
+	_history.load( in );
 }
 
 void Replxx::ReplxxImpl::history_clear( void ) {

--- a/src/replxx_impl.hxx
+++ b/src/replxx_impl.hxx
@@ -39,6 +39,7 @@
 #include <thread>
 #include <mutex>
 #include <chrono>
+#include <iosfwd>
 
 #include "replxx.hxx"
 #include "history.hxx"
@@ -160,7 +161,9 @@ public:
 	void history_add( std::string const& line );
 	bool history_sync( std::string const& filename );
 	bool history_save( std::string const& filename );
+	void history_save( std::ostream& out );
 	bool history_load( std::string const& filename );
+	void history_load( std::istream& in );
 	void history_clear( void );
 	Replxx::HistoryScan::impl_t history_scan( void ) const;
 	int history_size( void ) const;


### PR DESCRIPTION
Makes it possible to read/write the history from memory or existing `fstream`.
I did not convert the construction of two `fstreams` in `bool History::save` to one `fstream` to keep the semantical equality.