### PR TITLE
Implement set_prompt to change the prompt during requested imput

### DIFF
--- a/include/replxx.h
+++ b/include/replxx.h
@@ -408,6 +408,12 @@ REPLXX_IMPEXP int replxx_print( Replxx*, char const* fmt, ... );
  */
 REPLXX_IMPEXP int replxx_write( Replxx*, char const* str, int length );
 
+/*! \brief Changes the prompt when input is being requested
+ *
+ * \param prompt - The prompt string to change to.
+ */
+REPLXX_IMPEXP void replxx_set_prompt( Replxx*, const char* prompt );
+
 /*! \brief Schedule an emulated key press event.
  *
  * \param code - key press code to be emulated.

--- a/include/replxx.hxx
+++ b/include/replxx.hxx
@@ -453,6 +453,12 @@ public:
 	 */
 	void write( char const* str, int length );
 
+	/*! \brief Changes the prompt when input is being requested
+	 *
+	 * \param prompt - The prompt string to change to.
+	 */
+	void set_prompt( std::string prompt );
+
 	/*! \brief Schedule an emulated key press event.
 	 *
 	 * \param code - key press code to be emulated.

--- a/src/prompt.hxx
+++ b/src/prompt.hxx
@@ -11,12 +11,13 @@ namespace replxx {
 class Prompt {           // a convenience struct for grouping prompt info
 public:
 	UnicodeString _text;   // our copy of the prompt text, edited
-	int _characterCount;   // visible characters in _text
-	int _extraLines;       // extra lines (beyond 1) occupied by prompt
-	int _lastLinePosition; // index into _text where last line begins
-	int _cursorRowOffset;  // where the cursor is relative to the start of the prompt
+	int _characterCount{0};   // visible characters in _text
+	int _extraLines{0};       // extra lines (beyond 1) occupied by prompt
+	int _lastLinePosition{0}; // index into _text where last line begins
+	int _cursorRowOffset{0};  // where the cursor is relative to the start of the prompt
+
 private:
-	int _screenColumns;    // width of screen in columns [cache]
+	int _screenColumns{0};    // width of screen in columns [cache]
 	Terminal& _terminal;
 public:
 	Prompt( Terminal& );

--- a/src/replxx.cxx
+++ b/src/replxx.cxx
@@ -282,6 +282,9 @@ void Replxx::write( char const* str, int length ) {
 	return ( _impl->print( str, length ) );
 }
 
+void Replxx::set_prompt( std::string prompt ) {
+	return ( _impl->set_prompt( std::move(prompt) ) );
+}
 }
 
 ::Replxx* replxx_init() {
@@ -393,6 +396,11 @@ int replxx_write( ::Replxx* replxx_, char const* str, int length ) {
 		return ( -1 );
 	}
 	return static_cast<int>( length );
+}
+
+void replxx_set_prompt( ::Replxx* replxx_, const char* prompt ) {
+	replxx::Replxx::ReplxxImpl* replxx( reinterpret_cast<replxx::Replxx::ReplxxImpl*>( replxx_ ) );
+	replxx->set_prompt(prompt);
 }
 
 struct replxx_completions {

--- a/src/replxx_impl.hxx
+++ b/src/replxx_impl.hxx
@@ -137,6 +137,8 @@ private:
 	Replxx::hint_callback_t _hintCallback;
 	key_presses_t _keyPresses;
 	messages_t _messages;
+	std::string _updated_prompt;
+	bool _is_prompt_updated;
 	completions_t _completions;
 	int _completionContextLength;
 	int _completionSelection;
@@ -181,6 +183,7 @@ public:
 	void enable_bracketed_paste( void );
 	void disable_bracketed_paste( void );
 	void print( char const*, int );
+	void set_prompt( std::string prompt );
 	Replxx::ACTION_RESULT clear_screen( char32_t );
 	void emulate_key_press( char32_t );
 	Replxx::ACTION_RESULT invoke( Replxx::ACTION, char32_t );


### PR DESCRIPTION
Can be used to change the prompt to reflect progress bars and progress indicators.

![Animation4](https://user-images.githubusercontent.com/1146834/131253918-7ab995c5-46d1-4b9a-9e2a-70a60f1bfec0.gif)

