### PR TITLE
Fix null pointers passed to memcmp detected by UBSan

### DIFF
--- a/src/utf8string.hxx
+++ b/src/utf8string.hxx
@@ -68,7 +68,8 @@ public:
 	}
 
 	bool operator != ( Utf8String const& other_ ) {
-		return ( ( other_._len != _len ) || ( memcmp( other_._data.get(), _data.get(), _len ) != 0 ) );
+		return ( ( other_._len != _len ) || ( ( _len != 0) && ( other_._len != 0)
+			&& ( memcmp( other_._data.get(), _data.get(), _len ) != 0 ) ) );
 	}
 
 private:


### PR DESCRIPTION
* /replxx/src/utf8string.hxx:71:49: runtime error: null pointer passed as argument 1, which is declared to never be null
    /usr/include/string.h:65:33: note: nonnull attribute specified here
    -0 0x7f66c06fe59d in replxx::Utf8String::operator!=(replxx::Utf8String const&)
    -1 0x7f66c06e8ce8 in replxx::Replxx::ReplxxImpl::handle_hints(replxx::Replxx::ReplxxImpl::HINT_ACTION)
    -2 0x7f66c06dfb93 in replxx::Replxx::ReplxxImpl::refresh_line(replxx::Replxx::ReplxxImpl::HINT_ACTION)