### PR TITLE
Fix a race condition between ReplxxImpl::print and ReplxxImpl::input detected by TSan

### DIFF
--- a/src/replxx_impl.cxx
+++ b/src/replxx_impl.cxx
@@ -312,6 +312,12 @@ Replxx::ReplxxImpl::ReplxxImpl( FILE*, FILE*, FILE* )
 }
 
 Replxx::ReplxxImpl::~ReplxxImpl( void ) {
+	while ( ! _messages.empty() ) {
+		string const& message( _messages.front() );
+		_terminal.write8( message.data(), static_cast<int>( message.length() ) );
+		_messages.pop_front();
+	}
+
 	disable_bracketed_paste();
 }
 

--- a/src/replxx_impl.hxx
+++ b/src/replxx_impl.hxx
@@ -31,6 +31,7 @@
 #ifndef HAVE_REPLXX_REPLXX_IMPL_HXX_INCLUDED
 #define HAVE_REPLXX_REPLXX_IMPL_HXX_INCLUDED 1
 
+#include <atomic>
 #include <vector>
 #include <deque>
 #include <memory>
@@ -130,7 +131,7 @@ private:
 	named_actions_t _namedActions;
 	key_press_handlers_t _keyPressHandlers;
 	Terminal _terminal;
-	std::thread::id _currentThread;
+	std::atomic<std::thread::id> _currentThread;
 	Prompt _prompt;
 	Replxx::modify_callback_t _modifyCallback;
 	Replxx::completion_callback_t _completionCallback;


### PR DESCRIPTION
Using `_currentThread` for preventing locking a mutex is not really threadsafe anymore since the addition of `ReplxxImpl::print`.
This is because resetting `_currentThread` when `ReplxxImpl::prompt` ends causes issues when other threads still issue log messages through `ReplxxImpl::print`. This patch fixes the race condition by preventing calling `ReplxxImpl::prompt` from different threads so we can keep `_currentThread` persistent after the first invocation to `ReplxxImpl::prompt`.