### PR TITLE
Fix conversion int=>short on clang

### DIFF
--- a/src/terminal.cxx
+++ b/src/terminal.cxx
@@ -704,7 +704,7 @@ void Terminal::clear_screen( CLEAR_SCREEN clearScreen_ ) {
 		_empty.resize( toWrite - 1, ' ' );
 		WriteConsoleA( consoleOut, _empty.data(), toWrite - 1, &nWritten, nullptr );
 	} else {
-		COORD scrollTarget = { 0, -inf.dwSize.Y };
+		COORD scrollTarget = { 0, (SHORT)-inf.dwSize.Y };
 		CHAR_INFO fill{ TEXT( ' ' ), inf.wAttributes };
 		SMALL_RECT scrollRect = { 0, 0, inf.dwSize.X, inf.dwSize.Y };
 		ScrollConsoleScreenBuffer( consoleOut, &scrollRect, nullptr, scrollTarget, &fill );


### PR DESCRIPTION
Fixes an error when compiling with clang about implicit  conversion of `-inf.dwSize.Y` to SHORT, since the minus operator converts it to `int`. Adding a static cast silences this.