### PR TITLE
Case insensitive history search and completion.

### DIFF
--- a/examples/cxx-api.cxx
+++ b/examples/cxx-api.cxx
@@ -357,6 +357,7 @@ int main( int argc_, char** argv_ ) {
 	bool promptInCallback( false );
 	bool indentMultiline( false );
 	bool bracketedPaste( false );
+	bool ignoreCaseSearch( false );
 	std::string keys;
 	std::string prompt;
 	int hintDelay( 0 );
@@ -368,6 +369,7 @@ int main( int argc_, char** argv_ ) {
 			case ( 'F' ): promptFan = true; break;
 			case ( 'P' ): promptInCallback = true; break;
 			case ( 'I' ): indentMultiline = true; break;
+			case ( 'i' ): ignoreCaseSearch = true; break;
 			case ( 'k' ): keys = (*argv_) + 1; break;
 			case ( 'd' ): hintDelay = std::stoi( (*argv_) + 1 ); break;
 			case ( 'h' ): examples.push_back( (*argv_) + 1 ); break;
@@ -417,6 +419,7 @@ int main( int argc_, char** argv_ ) {
 	if ( bracketedPaste ) {
 		rx.enable_bracketed_paste();
 	}
+	rx.set_ignore_case_search( ignoreCaseSearch );
 
 	// showcase key bindings
 	rx.bind_key_internal( Replxx::KEY::BACKSPACE,                      "delete_character_left_of_cursor" );

--- a/include/replxx.h
+++ b/include/replxx.h
@@ -387,6 +387,12 @@ REPLXX_IMPEXP void replxx_get_state( Replxx*, ReplxxState* state );
  */
 REPLXX_IMPEXP void replxx_set_state( Replxx*, ReplxxState* state );
 
+/*! \brief Enable/disable case insensitive history search and completion.
+ *
+ * \param val - if set to non-zero then history search and completion will be case insensitive.
+ */
+REPLXX_IMPEXP void replxx_set_ignore_case_search( Replxx*, int val );
+
 /*! \brief Print formatted string to standard output.
  *
  * This function ensures proper handling of ANSI escape sequences

--- a/include/replxx.hxx
+++ b/include/replxx.hxx
@@ -433,6 +433,12 @@ public:
 	 */
 	void set_state( State const& state );
 
+	/*! \brief Enable/disable case insensitive history search and completion.
+	 *
+	 * \param val - if set to non-zero then history search and completion will be case insensitive.
+	 */
+	void set_ignore_case_search( bool val );
+
 	/*! \brief Print formatted string to standard output.
 	 *
 	 * This function ensures proper handling of ANSI escape sequences

--- a/src/history.cxx
+++ b/src/history.cxx
@@ -303,11 +303,11 @@ void History::restore_pos( void ) {
 	_current = _previous;
 }
 
-bool History::common_prefix_search( UnicodeString const& prefix_, int prefixSize_, bool back_ ) {
+bool History::common_prefix_search( UnicodeString const& prefix_, int prefixSize_, bool back_, bool ignoreCase ) {
 	int step( back_ ? -1 : 1 );
 	entries_t::const_iterator it( moved( _current, step, true ) );
 	while ( it != _current ) {
-		if ( it->text().starts_with( prefix_.begin(), prefix_.begin() + prefixSize_ ) ) {
+		if ( it->text().starts_with( prefix_.begin(), prefix_.begin() + prefixSize_, ignoreCase ? case_insensitive_equal : case_sensitive_equal ) ) {
 			_current = it;
 			commit_index();
 			return ( true );

--- a/src/history.hxx
+++ b/src/history.hxx
@@ -103,7 +103,7 @@ public:
 		return ( _yankPos->text() );
 	}
 	void jump( bool, bool = true );
-	bool common_prefix_search( UnicodeString const&, int, bool );
+	bool common_prefix_search( UnicodeString const&, int, bool, bool );
 	int size( void ) const {
 		return ( static_cast<int>( _entries.size() ) );
 	}

--- a/src/replxx.cxx
+++ b/src/replxx.cxx
@@ -266,6 +266,10 @@ void Replxx::set_state( Replxx::State const& state_ ) {
 	_impl->set_state( state_ );
 }
 
+void Replxx::set_ignore_case_search( bool val ) {
+	_impl->set_ignore_case_search( val );
+}
+
 int Replxx::install_window_change_handler( void ) {
 	return ( _impl->install_window_change_handler() );
 }
@@ -388,6 +392,11 @@ void replxx_get_state( ::Replxx* replxx_, ReplxxState* state ) {
 void replxx_set_state( ::Replxx* replxx_, ReplxxState* state ) {
 	replxx::Replxx::ReplxxImpl* replxx( reinterpret_cast<replxx::Replxx::ReplxxImpl*>( replxx_ ) );
 	replxx->set_state( replxx::Replxx::State( state->text, state->cursorPosition ) );
+}
+
+void replxx_set_ignore_case_search( ::Replxx* replxx_, int val ) {
+	replxx::Replxx::ReplxxImpl* replxx( reinterpret_cast<replxx::Replxx::ReplxxImpl*>( replxx_ ) );
+	replxx->set_ignore_case_search( val );
 }
 
 /**

--- a/src/replxx_impl.hxx
+++ b/src/replxx_impl.hxx
@@ -156,6 +156,7 @@ private:
 	bool _hasNewlines;
 	int _oldPos;
 	bool _moveCursor;
+	bool _ignoreCaseSearch;
 	mutable std::mutex _mutex;
 public:
 	ReplxxImpl( FILE*, FILE*, FILE* );
@@ -200,6 +201,7 @@ public:
 	void bind_key_internal( char32_t, char const* );
 	Replxx::State get_state( void ) const;
 	void set_state( Replxx::State const& );
+	void set_ignore_case_search( bool val );
 private:
 	ReplxxImpl( ReplxxImpl const& ) = delete;
 	ReplxxImpl& operator = ( ReplxxImpl const& ) = delete;

--- a/src/unicodestring.hxx
+++ b/src/unicodestring.hxx
@@ -9,6 +9,14 @@
 
 namespace replxx {
 
+inline bool case_sensitive_equal( char32_t l, char32_t r ) {
+	return l == r;
+}
+
+inline bool case_insensitive_equal( char32_t l, char32_t r ) {
+	return tolower(l) == tolower(r);
+}
+
 class UnicodeString {
 public:
 	typedef std::vector<char32_t> data_buffer_t;
@@ -97,6 +105,10 @@ public:
 		return ( _data != other_._data );
 	}
 
+	bool operator < ( UnicodeString const& other_ ) const {
+		return std::lexicographical_compare(begin(), end(), other_.begin(), other_.end());
+	}
+
 	UnicodeString& append( UnicodeString const& other ) {
 		_data.insert( _data.end(), other._data.begin(), other._data.end() );
 		return *this;
@@ -161,6 +173,14 @@ public:
 		return (
 			( std::distance( first_, last_ ) <= length() )
 			&& ( std::equal( first_, last_, _data.begin() ) )
+		);
+	}
+
+	template <class BinaryPredicate>
+	bool starts_with( data_buffer_t::const_iterator first_, data_buffer_t::const_iterator last_, BinaryPredicate&& pred ) const {
+		return (
+			( std::distance( first_, last_ ) <= length() )
+			&& ( std::equal( first_, last_, _data.begin(), std::forward<BinaryPredicate>(pred) ) )
 		);
 	}
 


### PR DESCRIPTION
After switching clickhouse-client to use the upstream replxx, we found three missing PRs in our fork which are lost.

1. https://github.com/ClickHouse-Extras/replxx/pull/3
2. https://github.com/ClickHouse-Extras/replxx/pull/4
3. https://github.com/ClickHouse-Extras/replxx/pull/15

I wonder if it's ok to land)