### PR TITLE
fix tick on Windows

### DIFF
--- a/src/replxx_impl.cxx
+++ b/src/replxx_impl.cxx
@@ -622,7 +622,7 @@ char const* Replxx::ReplxxImpl::input( std::string const& prompt ) {
 			_errorMessage.clear();
 		}
 		if ( isUnsupportedTerm() ) {
-			cout << prompt << flush;
+			printf( "%s", prompt.c_str() );
 			fflush( stdout );
 			return ( read_from_stdin() );
 		}

--- a/src/replxx_impl.cxx
+++ b/src/replxx_impl.cxx
@@ -453,6 +453,9 @@ char32_t Replxx::ReplxxImpl::read_char( HINT_ACTION hintAction_ ) {
 		}
 
 		std::lock_guard<std::mutex> l( _mutex );
+		if ( _updatePrompt ) {
+			_terminal.set_cursor_visible( false );
+		}
 		clear_self_to_end_of_screen();
 
 		if ( _updatePrompt ) {

--- a/src/terminal.cxx
+++ b/src/terminal.cxx
@@ -127,15 +127,14 @@ void Terminal::write32( char32_t const* text32, int len32 ) {
 
 void Terminal::write8( char const* data_, int size_ ) {
 #ifdef _WIN32
-	bool temporarilyEnabled( false );
+  int nWritten( 0 );
 	if ( ! _rawMode ) {
 		enable_out();
-		temporarilyEnabled = true;
-	}
-	int nWritten( win_write( _consoleOut, _autoEscape, data_, size_ ) );
-	if ( temporarilyEnabled ) {
+    nWritten = win_write( _consoleOut, _autoEscape, data_, size_ );
 		disable_out();
-	}
+	} else {
+    nWritten = write( 1, data_, size_ );
+  }
 #else
 	int nWritten( write( 1, data_, size_ ) );
 #endif


### PR DESCRIPTION
after some try I found the c++-api examples' tick can not run on Windows:
```
C:\Work\Sources\replxx>example.exe m
Welcome to Replxx
Press 'tab' to view autocompletions
Type '.help' for help
Type '.quit' or '.exit' to exit

0

Exiting Replxx
```

It causes by "write failed" runtime error, because `WrtieConsoleA` in src/windows.cxx:131 returns 6: invalid handle. it seems the logic in `terminal::writeB` are not correct, this is the fix.

btw I also removed the only one `cout` occurs in source.