### PR TITLE
fix shared library in windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,10 +75,9 @@ target_include_directories(
 )
 target_compile_definitions(
 	replxx
-	PUBLIC
-		$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:REPLXX_STATIC>
-		$<$<BOOL:${BUILD_SHARED_LIBS}>:REPLXX_BUILDING_DLL>
 	PRIVATE
+		$<$<NOT:$<BOOL:${BUILD_SHARED_LIBS}>>:REPLXX_STATIC>
+		$<$<BOOL:${BUILD_SHARED_LIBS}>:REPLXX_BUILDING_DLL>	
 		$<$<CXX_COMPILER_ID:MSVC>:_CRT_SECURE_NO_WARNINGS=1 /ignore:4503>
 )
 target_compile_options(

--- a/include/replxx.hxx
+++ b/include/replxx.hxx
@@ -260,7 +260,7 @@ public:
 		}
 	};
 	class HistoryScanImpl;
-	class HistoryScan {
+	class REPLXX_IMPEXP HistoryScan {
 	public:
 		typedef std::unique_ptr<HistoryScanImpl, void (*)( HistoryScanImpl* )> impl_t;
 	private:
@@ -663,35 +663,35 @@ namespace color {
  * \param color2 - second input color.
  * \return A new color definition that represent combined input colors.
  */
-Replxx::Color operator | ( Replxx::Color color1, Replxx::Color color2 );
+Replxx::Color REPLXX_IMPEXP operator | ( Replxx::Color color1, Replxx::Color color2 );
 
 /*! \brief Transform foreground color definition into a background color definition.
  *
  * \param color - an input foreground color definition.
  * \return A background color definition that is a transformed input \e color.
  */
-Replxx::Color bg( Replxx::Color color );
+Replxx::Color REPLXX_IMPEXP bg( Replxx::Color color );
 
 /*! \brief Add `bold` attribute to color definition.
  *
  * \param color - an input color definition.
  * \return A new color definition with bold attribute set.
  */
-Replxx::Color bold( Replxx::Color color );
+Replxx::Color REPLXX_IMPEXP bold( Replxx::Color color );
 
 /*! \brief Add `underline` attribute to color definition.
  *
  * \param color - an input color definition.
  * \return A new color definition with underline attribute set.
  */
-Replxx::Color underline( Replxx::Color color );
+Replxx::Color REPLXX_IMPEXP underline( Replxx::Color color );
 
 /*! \brief Create a new grayscale color of given brightness level.
  *
  * \param level - a brightness level for new color, must be between 0 (darkest) and 23 (brightest).
  * \return A new grayscale color of a given brightest \e level.
  */
-Replxx::Color grayscale( int level );
+Replxx::Color REPLXX_IMPEXP grayscale( int level );
 
 /*! \brief Create a new color in 6×6×6 RGB color space from base component levels.
  *
@@ -700,7 +700,7 @@ Replxx::Color grayscale( int level );
  * \param blue - a blue (of RGB) component level, must be 0 and 5.
  * \return A new color in 6×6×6 RGB color space.
  */
-Replxx::Color rgb666( int red, int green, int blue );
+Replxx::Color REPLXX_IMPEXP rgb666( int red, int green, int blue );
 
 }
 


### PR DESCRIPTION
When compiling with commands `cmake -DCMAKE_INSTALL_PREFIX=replxx -DBUILD_SHARED_LIBS=ON -G "MinGW Makefiles" .. & make` on windows, we will get such some errors as ` undefined reference to replxx::color::bold(replxx::Replxx::Color); undefined reference to replxx::Replxx::HistoryScan::next()`

