### PR TITLE
Fix uncaught exception from ReplxxImpl dtor

### DIFF
--- a/src/replxx_impl.cxx
+++ b/src/replxx_impl.cxx
@@ -334,7 +334,12 @@ Replxx::ReplxxImpl::ReplxxImpl( FILE*, FILE*, FILE* )
 }
 
 Replxx::ReplxxImpl::~ReplxxImpl( void ) {
-	disable_bracketed_paste();
+	try {
+		disable_bracketed_paste();
+	} catch ( std::runtime_error const& ) {
+		// suppress "write failed" errors (see Terminal::write8()).
+		// in case of i.e. broken pipe.
+	}
 }
 
 Replxx::ACTION_RESULT Replxx::ReplxxImpl::invoke( Replxx::ACTION action_, char32_t code ) {


### PR DESCRIPTION
You may get uncaugh exception (in case of i.e. broken pipe):

    terminating with uncaught exception of type std::runtime_error: write failed

On destroy:

    (lldb) target create "clickhouse-22.8-release" --core "core.clickhouse-clie.402986-642410"
    bt
    Core file '/wrk/core.clickhouse-clie.402986-642410' (x86_64) was loaded.
    (lldb) bt
    * thread #1, name = 'clickhouse-clie', stop reason = signal SIGABRT
      * frame #0: 0x00007f03fb5c900b libc.so.6`raise + 203
        frame #1: 0x00007f03fb5a8859 libc.so.6`abort + 299
        frame #2: 0x000000001b703f44 clickhouse-22.8-release`::abort_message(format=<unavailable>) at abort_message.cpp:78:5
        frame #3: 0x000000001b703dd4 clickhouse-22.8-release`demangling_terminate_handler() at cxa_default_handlers.cpp:67:21
        frame #4: 0x000000001b721063 clickhouse-22.8-release`std::__terminate(func=<unavailable>)()) at cxa_handlers.cpp:59:9
        frame #5: 0x000000001b720fce clickhouse-22.8-release`std::terminate() at cxa_handlers.cpp:88:17
        frame #6: 0x000000000a3b21db clickhouse-22.8-release`__clang_call_terminate + 11
        frame #7: 0x00000000189b1bfc clickhouse-22.8-release`replxx::Replxx::ReplxxImpl::~ReplxxImpl(this=0x00007f03fa945308) at replxx_impl.cxx:336:1
        frame #8: 0x00000000189b1ce9 clickhouse-22.8-release`replxx::Replxx::ReplxxImpl::~ReplxxImpl(this=0x00007f03fa945300) at replxx_impl.cxx:334:41
        frame #9: 0x00000000188b0644 clickhouse-22.8-release`ReplxxLineReader::~ReplxxLineReader() [inlined] std::__1::unique_ptr<replxx::Replxx::ReplxxImpl, void (*)(replxx::Replxx::ReplxxImpl*)>::reset(this=<unavailable>, __p=<unavailable>) at unique_ptr.h:315:7
        frame #10: 0x00000000188b0626 clickhouse-22.8-release`ReplxxLineReader::~ReplxxLineReader() [inlined] std::__1::unique_ptr<replxx::Replxx::ReplxxImpl, void (*)(replxx::Replxx::ReplxxImpl*)>::~unique_ptr(this=<unavailable>) at unique_ptr.h:269
        frame #11: 0x00000000188b0626 clickhouse-22.8-release`ReplxxLineReader::~ReplxxLineReader() [inlined] replxx::Replxx::~Replxx(this=<unavailable>) at replxx.hxx:76
        frame #12: 0x00000000188b0626 clickhouse-22.8-release`ReplxxLineReader::~ReplxxLineReader(this=0x00007ffd10038440) at ReplxxLineReader.cpp:229
        frame #13: 0x00000000158b2100 clickhouse-22.8-release`DB::ClientBase::runInteractive(this=0x00007ffd10038620) at ClientBase.cpp:2067:1
        frame #14: 0x000000000a4de372 clickhouse-22.8-release`DB::Client::main(this=0x00007ffd10038620, (null)=<unavailable>) at Client.cpp:261:9
        frame #15: 0x0000000018923a86 clickhouse-22.8-release`Poco::Util::Application::run(this=0x00007ffd10038620) at Application.cpp:334:8
        frame #16: 0x000000000a4ed341 clickhouse-22.8-release`mainEntryClickHouseClient(argc=39, argv=0x00007f03fa8201c0) at Client.cpp:1220:23
        frame #17: 0x000000000a3b17ab clickhouse-22.8-release`main(argc_=<unavailable>, argv_=<unavailable>) at main.cpp:449:12
        frame #18: 0x00007f03fb5aa083 libc.so.6`__libc_start_main + 243
        frame #19: 0x000000000a17032e clickhouse-22.8-release`_start + 46