### PR TITLE
Multiline input history previous line crash fix

### DIFF
--- a/src/replxx_impl.cxx
+++ b/src/replxx_impl.cxx
@@ -1883,7 +1883,7 @@ Replxx::ACTION_RESULT Replxx::ReplxxImpl::line_previous( char32_t ) {
 		}
 		int prevNewlinePosition( prev_newline_position( _pos ) );
 		if ( prevNewlinePosition == _pos ) {
-			prevNewlinePosition = prev_newline_position( _pos - 1 );
+			prevNewlinePosition = _pos > 0 ? prev_newline_position( _pos - 1 ) : -1;
 		}
 		if ( prevNewlinePosition < 0 ) {
 			break;


### PR DESCRIPTION
Replxx crashes during history previous line command, when input contains mutliple consecutive '\n' characters.

Reproducible example:
```
./replxx-example-cxx-api B
Welcome to Replxx
Press 'tab' to view autocompletions
Type '.help' for help
Type '.quit' or '.exit' to exit

replxx>  
 
replxx> 







replxx> 







replxx> replxx-example-cxx-api: replxx/src/replxx_impl.cxx:1844: int replxx::Replxx::ReplxxImpl::prev_newline_position(int) const: Assertion `( pos_ >= 0 ) && ( pos_ <= _data.length() )' failed.
Aborted (core dumped)
```